### PR TITLE
Bug 1187331 - remove unused/incorrect fields from task definition.

### DIFF
--- a/taskcluster/get_task.go
+++ b/taskcluster/get_task.go
@@ -8,14 +8,8 @@ import (
 
 // This is an incomplete mapping of tasks from taskcluster...
 type queueTask struct {
-	ProvisonerId string   `json:"provisionerId"`
-	WorkerType   string   `json:"workerType"`
-	Routing      string   `json:"routing"`
-	Retires      int      `json:"retries"`
-	Priority     int      `json:"priority"`
-	Created      string   `json:"created"`
-	Deadline     string   `json:"deadline"`
-	Scopes       []string `json:"scopes"`
+	// only scopes are needed
+	Scopes []string `json:"scopes"`
 }
 
 var taskUrl = "https://queue.taskcluster.net/v1/task/%s"


### PR DESCRIPTION
The taskcluster proxy retrieves a task definition from the queue in order to read the scopes. Formerly, it was reading a bunch of fields that were unused. This broke when "priority" was re-added (presumably it existed a while ago) but now as a string (it was formerly an int, by the look of things).

Therefore we should only read "scopes" since that is all that is processed, and task definition can evolve over time, so no reason to read stuff that could break if the task definition changes.