### PR TITLE
Bug 1234890 - add a response header with taskcluster proxy version

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -117,6 +117,7 @@ func (self Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	}
 
 	headersToSend.Set("X-Taskcluster-Endpoint", targetPath.String())
+	headersToSend.Set("X-Taskcluster-Version", version)
 
 	// Write the proxyResponse headers and status.
 	res.WriteHeader(proxyResp.StatusCode)

--- a/routes.go
+++ b/routes.go
@@ -117,7 +117,7 @@ func (self Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	}
 
 	headersToSend.Set("X-Taskcluster-Endpoint", targetPath.String())
-	headersToSend.Set("X-Taskcluster-Version", version)
+	headersToSend.Set("X-Taskcluster-Proxy-Version", version)
 
 	// Write the proxyResponse headers and status.
 	res.WriteHeader(proxyResp.StatusCode)


### PR DESCRIPTION
This extra information can only be useful.