### PR TITLE
Fix broken proxy... dummy body and missing response

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -77,6 +76,9 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			fmt.Fprintf(res, "Failed to generate proxy request (could not read http body) - %s", err)
 			return
 		}
+		if len(body) == 0 {
+		  body = nil
+		}
 	}
 
 	cd := tcclient.ConnectionData(*self)
@@ -106,6 +108,7 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	res.WriteHeader(cs.HttpResponse.StatusCode)
 
 	// Proxy the proxyResponse body from the endpoint to our response.
-	io.Copy(res, cs.HttpResponse.Body)
+	res.Write([]byte(cs.HttpResponseBody))
+	//io.Copy(res, []byte(cs.HttpResponseBody))
 	cs.HttpResponse.Body.Close()
 }


### PR DESCRIPTION
Generally I think the proxy have taken a bad direction...

This will support services that only do JSON like the ones we have...

But really, we should support signing any request on the form: `taskcluster/<host>/<path>`
Hence, queue would be `taskcluster/queue.taskcluster.net/v1/ping`

This way, anyone who adds taskcluster authentication to his app, can use the proxy...
But to this we need to not use TC-client for this... because we want to be streaming the result through not storing it in memory... This is important as some services may take huge payloads. I dream that maybe one day releng-api, balrog, who knows could use TC creds...

For them it's pretty simple to call `auth.tc.net` with the `authorization` header and ask if the request has a certain scope. So it's not completely unthinkable.