### PR TITLE
Bug 1241107 - fix taskcluster-proxy to work with http request payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ To run the full test suites you need taskcluster credentials with at least the
 following scopes:
 
   * `auth:azure-table-access:fakeaccount/DuMmYtAbLe`
+  * `queue:define-task:win-provisioner/win2008-worker`
   * `queue:get-artifact:private/build/sources.xml`
+  * `queue:route:tc-treeherder-stage.mozilla-inbound.*`
+  * `queue:route:tc-treeherder.mozilla-inbound.*`
+  * `queue:task-priority:high`
+  * `test-worker:image:toastposter/pumpkin:0.5.6`
 
 The credentials are expected to be in the `TASKCLUSTER_CLIENT_ID` and
 `TASKCLUSTER_ACCESS_TOKEN` environment variables (and optionally the

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/taskcluster/httpbackoff"
+	"github.com/taskcluster/slugid-go/slugid"
 	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
@@ -49,7 +50,15 @@ func testWithPermCreds(t *testing.T, test IntegrationTest) {
 
 func testWithTempCreds(t *testing.T, test IntegrationTest) {
 	skipIfNoPermCreds(t)
-	tempCredentials, err := permCredentials.CreateTemporaryCredentials(1*time.Hour, "queue:get-artifact:private/build/sources.xml", "auth:azure-table-access:fakeaccount/DuMmYtAbLe")
+	tempCredentials, err := permCredentials.CreateTemporaryCredentials(1*time.Hour,
+		"auth:azure-table-access:fakeaccount/DuMmYtAbLe",
+		"queue:define-task:win-provisioner/win2008-worker",
+		"queue:get-artifact:private/build/sources.xml",
+		"queue:route:tc-treeherder.mozilla-inbound.*",
+		"queue:route:tc-treeherder-stage.mozilla-inbound.*",
+		"queue:task-priority:high",
+		"test-worker:image:toastposter/pumpkin:0.5.6",
+	)
 	if err != nil {
 		t.Fatalf("Could not generate temp credentials")
 	}
@@ -134,4 +143,135 @@ func TestAuthorizationDelegate(t *testing.T) {
 	testWithTempCreds(t, test("B", 404, []string{"auth:azure-table-access:fakeaccount/DuMmYtAbLe"}))
 	testWithPermCreds(t, test("C", 401, []string{"queue:get-artifact:private/build/sources.xml"}))
 	testWithTempCreds(t, test("D", 401, []string{"queue:get-artifact:private/build/sources.xml"}))
+}
+
+func TestAPICallWithPayload(t *testing.T) {
+	test := func(t *testing.T, creds *tcclient.Credentials) {
+
+		// Test setup
+		routes := Routes(tcclient.ConnectionData{
+			Authenticate: true,
+			Credentials:  creds,
+		})
+		taskId := slugid.Nice()
+		taskGroupId := slugid.Nice()
+		created := time.Now()
+		deadline := created.AddDate(0, 0, 1)
+		expires := deadline
+
+		req, err := http.NewRequest(
+			"POST",
+			"https://localhost:60024/queue/v1/task/"+taskId+"/define",
+			bytes.NewBufferString(
+				`
+{
+  "provisionerId": "win-provisioner",
+  "workerType": "win2008-worker",
+  "schedulerId": "go-test-test-scheduler",
+  "taskGroupId": "`+taskGroupId+`",
+  "routes": [
+    "tc-treeherder.mozilla-inbound.bcf29c305519d6e120b2e4d3b8aa33baaf5f0163",
+    "tc-treeherder-stage.mozilla-inbound.bcf29c305519d6e120b2e4d3b8aa33baaf5f0163"
+  ],
+  "priority": "high",
+  "retries": 5,
+  "created": "`+tcclient.Time(created).String()+`",
+  "deadline": "`+tcclient.Time(deadline).String()+`",
+  "expires": "`+tcclient.Time(expires).String()+`",
+  "scopes": [
+    "test-worker:image:toastposter/pumpkin:0.5.6"
+  ],
+  "payload": {
+    "features": {
+      "relengApiProxy": true
+    }
+  },
+  "metadata": {
+    "description": "Stuff",
+    "name": "[TC] Pete",
+    "owner": "pmoore@mozilla.com",
+    "source": "http://everywhere.com/"
+  },
+  "tags": {
+    "createdForUser": "cbook@mozilla.com"
+  },
+  "extra": {
+    "index": {
+      "rank": 12345
+    }
+  }
+}
+`,
+			),
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		res := httptest.NewRecorder()
+
+		// Function to test
+		routes.ServeHTTP(res, req)
+
+		// Validate results
+		if res.Code != 200 {
+			t.Logf("Expected status code 200 but got %v", res.Code)
+			respBody, err := ioutil.ReadAll(res.Body)
+			t.Logf("Headers: %s", res.Header())
+			if err == nil {
+				t.Logf("Response received:\n%s", string(respBody))
+			}
+			t.FailNow()
+		}
+		t.Logf("Created task https://queue.taskcluster.net/v1/task/%v", taskId)
+	}
+	testWithPermCreds(t, test)
+	testWithTempCreds(t, test)
+}
+
+func TestNon200HasErrorBody(t *testing.T) {
+	test := func(t *testing.T, creds *tcclient.Credentials) {
+
+		// Test setup
+		routes := Routes(tcclient.ConnectionData{
+			Authenticate: true,
+			Credentials:  creds,
+		})
+		taskId := slugid.Nice()
+
+		req, err := http.NewRequest(
+			"POST",
+			"https://localhost:60024/queue/v1/task/"+taskId+"/define",
+			bytes.NewBufferString(
+				`<bad!-payL0ad@%% `,
+			),
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		res := httptest.NewRecorder()
+
+		// Function to test
+		routes.ServeHTTP(res, req)
+
+		respBody, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatalf("Could not read response body: %v", err)
+		}
+		// Validate results
+		if res.Code != 400 {
+			t.Logf("Expected status code 400 but got %v", res.Code)
+			t.Logf("Headers: %s", res.Header())
+			t.Logf("Response received:\n%s", string(respBody))
+			t.FailNow()
+		}
+		if len(respBody) < 20 {
+			t.Log("Expected a response body (at least 20 bytes) with HTTP 400 error, but get less (or none).")
+			t.Logf("Headers: %s", res.Header())
+			t.Logf("Response received:\n%s", string(respBody))
+			t.FailNow()
+		}
+
+	}
+	testWithPermCreds(t, test)
+	testWithTempCreds(t, test)
 }

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -72,7 +72,11 @@ func TestBewit(t *testing.T) {
 		routes := Routes(tcclient.ConnectionData{
 			Credentials: creds,
 		})
-		req, err := http.NewRequest("POST", "https://localhost:60024/bewit", bytes.NewBufferString("https://queue.taskcluster.net/v1/task/DD1kmgFiRMWTjyiNoEJIMA/runs/0/artifacts/private%2Fbuild%2Fsources.xml"))
+		req, err := http.NewRequest(
+			"POST",
+			"https://localhost:60024/bewit",
+			bytes.NewBufferString("https://queue.taskcluster.net/v1/task/DD1kmgFiRMWTjyiNoEJIMA/runs/0/artifacts/private%2Fbuild%2Fsources.xml"),
+		)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -117,7 +121,14 @@ func TestAuthorizationDelegate(t *testing.T) {
 				},
 			})
 
-			req, err := http.NewRequest("GET", sharedAccessSignature(), nil)
+			req, err := http.NewRequest(
+				"GET",
+				sharedAccessSignature(),
+				// Note: we don't set body to nil as a server http request
+				// cannot have a nil body. See:
+				// https://golang.org/pkg/net/http/#Request
+				new(bytes.Buffer),
+			)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -242,7 +242,7 @@ func TestNon200HasErrorBody(t *testing.T) {
 			"POST",
 			"https://localhost:60024/queue/v1/task/"+taskId+"/define",
 			bytes.NewBufferString(
-				`<bad!-payL0ad@%% `,
+				`{"comment": "Valid json so that we hit endpoint, but should not result in http 200"}`,
 			),
 		)
 		if err != nil {
@@ -265,9 +265,9 @@ func TestNon200HasErrorBody(t *testing.T) {
 			t.FailNow()
 		}
 		if len(respBody) < 20 {
-			t.Log("Expected a response body (at least 20 bytes) with HTTP 400 error, but get less (or none).")
 			t.Logf("Headers: %s", res.Header())
 			t.Logf("Response received:\n%s", string(respBody))
+			t.Log("Expected a response body (at least 20 bytes) with HTTP 400 error, but get less (or none).")
 			t.FailNow()
 		}
 

--- a/routes.go
+++ b/routes.go
@@ -68,7 +68,23 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	log.Printf("Proxying %s | %s | %s", req.URL, req.Method, targetPath)
 
 	payload := (*json.RawMessage)(nil)
+	// In theory, req.Body should never be nil when running as a server, but
+	// during testing, with a direct call to the method rather than a real http
+	// request coming in from outside, it could be. For example see:
+	// https://github.com/taskcluster/taskcluster-proxy/blob/6744fb1d3eaa791394fe651ff3a3f99f606828d5/authorization_test.go#L111
+	// Furthermore, it is correct to create an http (client) request with a nil
+	// body. See https://golang.org/pkg/net/http/#Request.
+	//
+	// Technically a client request should not be passed to a server method,
+	// but in reality there are not separate types (e.g. HttpClientRequest,
+	// HttpServerRequest) and so it can easily happen and is usually done.  For
+	// this reason, and to avoid confusion around this, let's keep the nil
+	// check in here.
 	if req.Body != nil {
+		// Note: we cannot use:
+		// `err := json.NewDecoder(req.Body).Decode(payload)` since the body
+		// might be empty and we'd get a json decoding error. Therefore we read
+		// into memory and test the length upfront.
 		body, err := ioutil.ReadAll(req.Body)
 		// If we fail to create a request notify the client.
 		if err != nil {
@@ -76,12 +92,14 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 			fmt.Fprintf(res, "Failed to generate proxy request (could not read http body) - %s", err)
 			return
 		}
-		payload = new(json.RawMessage)
-		err = json.Unmarshal(body, payload)
-		if err != nil {
-			res.WriteHeader(400)
-			fmt.Fprintf(res, "Malformed payload - http request body is not valid json - %s", err)
-			return
+		if len(body) > 0 {
+			payload = new(json.RawMessage)
+			err = json.Unmarshal(body, payload)
+			if err != nil {
+				res.WriteHeader(400)
+				fmt.Fprintf(res, "Malformed payload - http request body is not valid json - %s", err)
+				return
+			}
 		}
 	}
 


### PR DESCRIPTION
Unfortunately it seems I broke things. This PR has a fix and also adds a couple of tests:

1. Making sure that proxy requests with http request bodies (a.k.a payloads) work
2. Making sure that even when a request is not successful (e.g. http 400 from endpoint) that the message body is also proxied back to the requester, and not only in success cases.