### PR TITLE
Bug 1234929 - add extra headers for troubleshooting scopes issues

### DIFF
--- a/routes.go
+++ b/routes.go
@@ -125,6 +125,13 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	headersToSend.Set("X-Taskcluster-Endpoint", targetPath.String())
 	headersToSend.Set("X-Taskcluster-Proxy-Version", version)
+	cert, err := self.Credentials.Cert()
+	if err == nil && cert != nil {
+		headersToSend.Set("X-Taskcluster-Proxy-Temp-Scopes", fmt.Sprintf("%s", cert.Scopes))
+	}
+	if authScopes := self.Credentials.AuthorizedScopes; len(authScopes) > 0 {
+		headersToSend.Set("X-Taskcluster-Authorized-Scopes", fmt.Sprintf("%s", authScopes))
+	}
 
 	// Write the proxyResponse headers and status.
 	res.WriteHeader(cs.HttpResponse.StatusCode)

--- a/routes.go
+++ b/routes.go
@@ -129,7 +129,7 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	if err == nil && cert != nil {
 		headersToSend.Set("X-Taskcluster-Proxy-Temp-Scopes", fmt.Sprintf("%s", cert.Scopes))
 	}
-	if authScopes := self.Credentials.AuthorizedScopes; len(authScopes) > 0 {
+	if authScopes := self.Credentials.AuthorizedScopes; authScopes != nil {
 		headersToSend.Set("X-Taskcluster-Authorized-Scopes", fmt.Sprintf("%s", authScopes))
 	}
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,0 @@
-var x = "";
-if (x) {
-    console.log('yay');
-}

--- a/test.js
+++ b/test.js
@@ -1,0 +1,4 @@
+var x = "";
+if (x) {
+    console.log('yay');
+}


### PR DESCRIPTION
This adds the following headers to taskcluster-proxy http responses:

* `X-Taskcluster-Proxy-Temp-Scopes` (the unexpanded scopes the proxy has been granted, if using temporary credentials)
* `X-Taskcluster-Authorized-Scopes` (the unexpanded scopes the proxy has granted to the task)

This is to make it easier to audit which scopes the proxy has in general, and which scopes it has granted to the task, without relying on detailed information in error responses from the auth service.

Please note if the proxy is running with permanent credentials, it will not inject the `X-Taskcluster-Proxy-Temp-Scopes` header.