### PR TITLE
Bug 1220738: Create endpoint for credentials update. r=pmoore

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ The proxy runs fine natively, but if you wish, you can also create a docker imag
 ./build.sh user/taskcluster-proxy
 ```
 
+## Endpoints
+
+#### Credentials Update
+
+The proxy has the endpoint `/credentials` which accepts `PUT` request for
+credentials update. The body is a
+[Credentials](http://docs.taskcluster.net/queue/api-docs/#claimTask)
+object in json format.
+
 
 ## Running tests
 

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -142,9 +142,11 @@ func TestBewit(t *testing.T) {
 	test := func(t *testing.T, creds *tcclient.Credentials) *httptest.ResponseRecorder {
 
 		// Test setup
-		routes := Routes(tcclient.ConnectionData{
-			Credentials: creds,
-		})
+		routes := Routes{
+			ConnectionData: tcclient.ConnectionData{
+				Credentials: creds,
+			},
+		}
 		req, err := http.NewRequest(
 			"POST",
 			"http://localhost:60024/bewit",
@@ -186,15 +188,17 @@ func TestAuthorizationDelegate(t *testing.T) {
 	test := func(name string, scopes []string) IntegrationTest {
 		return func(t *testing.T, creds *tcclient.Credentials) *httptest.ResponseRecorder {
 			// Test setup
-			routes := Routes(tcclient.ConnectionData{
-				Authenticate: true,
-				Credentials: &tcclient.Credentials{
-					ClientId:         creds.ClientId,
-					AccessToken:      creds.AccessToken,
-					Certificate:      creds.Certificate,
-					AuthorizedScopes: scopes,
+			routes := Routes{
+				ConnectionData: tcclient.ConnectionData{
+					Authenticate: true,
+					Credentials: &tcclient.Credentials{
+						ClientId:         creds.ClientId,
+						AccessToken:      creds.AccessToken,
+						Certificate:      creds.Certificate,
+						AuthorizedScopes: scopes,
+					},
 				},
-			})
+			}
 
 			// Requires scope "auth:azure-table-access:fakeaccount/DuMmYtAbLe"
 			req, err := http.NewRequest(
@@ -229,10 +233,12 @@ func TestAPICallWithPayload(t *testing.T) {
 	test := func(t *testing.T, creds *tcclient.Credentials) *httptest.ResponseRecorder {
 
 		// Test setup
-		routes := Routes(tcclient.ConnectionData{
-			Authenticate: true,
-			Credentials:  creds,
-		})
+		routes := Routes{
+			ConnectionData: tcclient.ConnectionData{
+				Authenticate: true,
+				Credentials:  creds,
+			},
+		}
 		taskId := slugid.Nice()
 		taskGroupId := slugid.Nice()
 		created := time.Now()
@@ -303,10 +309,12 @@ func TestNon200HasErrorBody(t *testing.T) {
 	test := func(t *testing.T, creds *tcclient.Credentials) *httptest.ResponseRecorder {
 
 		// Test setup
-		routes := Routes(tcclient.ConnectionData{
-			Authenticate: true,
-			Credentials:  creds,
-		})
+		routes := Routes{
+			ConnectionData: tcclient.ConnectionData{
+				Authenticate: true,
+				Credentials:  creds,
+			},
+		}
 		taskId := slugid.Nice()
 
 		req, err := http.NewRequest(
@@ -336,10 +344,12 @@ func TestOversteppedScopes(t *testing.T) {
 	test := func(t *testing.T, creds *tcclient.Credentials) *httptest.ResponseRecorder {
 
 		// Test setup
-		routes := Routes(tcclient.ConnectionData{
-			Authenticate: true,
-			Credentials:  creds,
-		})
+		routes := Routes{
+			ConnectionData: tcclient.ConnectionData{
+				Authenticate: true,
+				Credentials:  creds,
+			},
+		}
 
 		// This scope is not in the scopes of the temp credentials, which would
 		// happen if a task declares a scope that the provisioner does not
@@ -374,14 +384,16 @@ func TestOversteppedScopes(t *testing.T) {
 }
 
 func TestBadCredsReturns500(t *testing.T) {
-	routes := Routes(tcclient.ConnectionData{
-		Authenticate: true,
-		Credentials: &tcclient.Credentials{
-			ClientId:    "abc",
-			AccessToken: "def",
-			Certificate: "ghi", // baaaad certificate
+	routes := Routes{
+		ConnectionData: tcclient.ConnectionData{
+			Authenticate: true,
+			Credentials: &tcclient.Credentials{
+				ClientId:    "abc",
+				AccessToken: "def",
+				Certificate: "ghi", // baaaad certificate
+			},
 		},
-	})
+	}
 	req, err := http.NewRequest(
 		"GET",
 		"http://localhost:60024/secrets/v1/secret/garbage/pmoore/foo",

--- a/credentials_update_test.go
+++ b/credentials_update_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type RoutesTest struct {
+	Routes
+	t *testing.T
+}
+
+func TestCredentialsUpdate(t *testing.T) {
+	newCreds := CredentialsUpdate{
+		ClientId:    "newClientId",
+		AccessToken: "newAccessToken",
+		Certificate: "newCertificate",
+	}
+
+	body, err := json.Marshal(&newCreds)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	routes := NewRoutesTest(t)
+
+	response := routes.request("POST", body)
+	if response.Code != 405 {
+		t.Errorf("Should return 405, but returned %d", response.Code)
+	}
+
+	response = routes.request("PUT", make([]byte, 0))
+	if response.Code != 400 {
+		t.Errorf("Should return 400, but returned %d", response.Code)
+	}
+
+	response = routes.request("PUT", body)
+	if response.Code != 200 {
+		content, _ := ioutil.ReadAll(response.Body)
+		t.Fatal("Request error %d: %s", response.Code, string(content))
+	}
+
+	if routes.Credentials.ClientId != newCreds.ClientId {
+		t.Errorf(
+			"ClientId should be \"%s\", but got \"%s\"",
+			newCreds.ClientId,
+			routes.Credentials.ClientId,
+		)
+	}
+
+	if routes.Credentials.AccessToken != newCreds.AccessToken {
+		t.Errorf(
+			"AccessToken should be \"%s\", but got \"%s\"",
+			newCreds.AccessToken,
+			routes.Credentials.AccessToken,
+		)
+	}
+
+	if routes.Credentials.Certificate != newCreds.Certificate {
+		t.Errorf(
+			"Certificate should be \"%s\", but got \"%s\"",
+			newCreds.Certificate,
+			routes.Credentials.Certificate,
+		)
+	}
+}
+
+func (self *RoutesTest) request(method string, content []byte) (res *httptest.ResponseRecorder) {
+	req, err := http.NewRequest(
+		method,
+		"http://localhost:8080/credentials",
+		bytes.NewBuffer(content),
+	)
+
+	if err != nil {
+		self.t.Fatal(err)
+	}
+
+	req.ContentLength = int64(len(content))
+	res = httptest.NewRecorder()
+	self.ServeHTTP(res, req)
+	return
+}
+
+func NewRoutesTest(t *testing.T) *RoutesTest {
+	return &RoutesTest{
+		Routes: Routes{
+			ConnectionData: tcclient.ConnectionData{
+				Authenticate: true,
+				Credentials: &tcclient.Credentials{
+					ClientId:    "clientId",
+					AccessToken: "accessToken",
+					Certificate: "certificate",
+				},
+			},
+		},
+		t: t,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -98,10 +98,12 @@ func main() {
 
 	log.Println("Proxy with scopes: ", creds.AuthorizedScopes)
 
-	routes := Routes(tcclient.ConnectionData{
-		Authenticate: true,
-		Credentials:  creds,
-	})
+	routes := Routes{
+		ConnectionData: tcclient.ConnectionData{
+			Authenticate: true,
+			Credentials:  creds,
+		},
+	}
 
 	startError := http.ListenAndServe(fmt.Sprintf(":%d", port), &routes)
 	if startError != nil {


### PR DESCRIPTION
docker-worker will use task temporary credentials for taskcluster
requests on task behalf.

During task reclaim, the temporary credentials might be updated, and
if using taskcluster-proxy to forward requests, we should update the
credentials in the proxy as well.

We create a "/Credentials" endpoint which receive PUT requests with
a json body containing the new credentials data for update.