### PR TITLE
Handle non-json responses from API calls

### DIFF
--- a/authorization_test.go
+++ b/authorization_test.go
@@ -380,7 +380,7 @@ func TestOversteppedScopes(t *testing.T) {
 		)
 		return res
 	}
-	testWithTempCreds(t, test, 500)
+	testWithTempCreds(t, test, 401)
 }
 
 func TestBadCredsReturns500(t *testing.T) {

--- a/credentials_update_test.go
+++ b/credentials_update_test.go
@@ -3,11 +3,12 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 type RoutesTest struct {
@@ -38,6 +39,12 @@ func TestCredentialsUpdate(t *testing.T) {
 	response = routes.request("PUT", make([]byte, 0))
 	if response.Code != 400 {
 		t.Errorf("Should return 400, but returned %d", response.Code)
+	}
+
+	response = routes.request("PUT", []byte("{\"badJS0n!"))
+	if response.Code != 400 {
+		content, _ := ioutil.ReadAll(response.Body)
+		t.Fatal("Request error %d: %s", response.Code, string(content))
 	}
 
 	response = routes.request("PUT", body)

--- a/routes.go
+++ b/routes.go
@@ -132,7 +132,6 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 
 	log.Printf("Proxying %s | %s | %s", req.URL, req.Method, targetPath)
 
-	payload := (*json.RawMessage)(nil)
 	// In theory, req.Body should never be nil when running as a server, but
 	// during testing, with a direct call to the method rather than a real http
 	// request coming in from outside, it could be. For example see:
@@ -145,31 +144,19 @@ func (self *Routes) ServeHTTP(res http.ResponseWriter, req *http.Request) {
 	// HttpServerRequest) and so it can easily happen and is usually done.  For
 	// this reason, and to avoid confusion around this, let's keep the nil
 	// check in here.
+	body := []byte{}
 	if req.Body != nil {
-		// Note: we cannot use:
-		// `err := json.NewDecoder(req.Body).Decode(payload)` since the body
-		// might be empty and we'd get a json decoding error. Therefore we read
-		// into memory and test the length upfront.
-		body, err := ioutil.ReadAll(req.Body)
+		body, err = ioutil.ReadAll(req.Body)
 		// If we fail to create a request notify the client.
 		if err != nil {
 			res.WriteHeader(500)
 			fmt.Fprintf(res, "Failed to generate proxy request (could not read http body) - %s", err)
 			return
 		}
-		if len(body) > 0 {
-			payload = new(json.RawMessage)
-			err = json.Unmarshal(body, payload)
-			if err != nil {
-				res.WriteHeader(400)
-				fmt.Fprintf(res, "Malformed payload - http request body is not valid json - %s", err)
-				return
-			}
-		}
 	}
 
 	cd := tcclient.ConnectionData(self.ConnectionData)
-	_, cs, err := (&cd).APICall(payload, req.Method, targetPath.String(), new(json.RawMessage), nil)
+	cs, err := (&cd).Request(body, req.Method, targetPath.String(), nil)
 	// If we fail to create a request notify the client.
 	if err != nil {
 		switch err.(type) {


### PR DESCRIPTION
I split out the json handling in `APICall` so there is now a client method `Request` that takes binary input and returns binary output, and `APICall` uses this, so no change to `APICall` functionality. However, taskcluster-proxy can now call the Request method directly, so doesn't need to pass json in/out but can proxy arbitrary binary data.

See associated change https://github.com/taskcluster/taskcluster-client-go/commit/f23fbec12ab177b9cf8d9e4a4e00fe0a1873e26c which made this possible.