### PR TITLE
Use http handlers for different endpoints

### DIFF
--- a/authorization_test.go
+++ b/authorization_test.go
@@ -79,6 +79,9 @@ func testWithTempCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 		"queue:task-priority:high",
 		"test-worker:image:toastposter/pumpkin:0.5.6",
 	}
+
+	tempScopesJSON := `["auth:azure-table-access:fakeaccount/DuMmYtAbLe","queue:define-task:win-provisioner/win2008-worker","queue:get-artifact:private/build/sources.xml","queue:route:tc-treeherder.mozilla-inbound.*","queue:route:tc-treeherder-stage.mozilla-inbound.*","queue:task-priority:high","test-worker:image:toastposter/pumpkin:0.5.6"]`
+
 	tempCredentials, err := permCredentials.CreateTemporaryCredentials(1*time.Hour, tempScopes...)
 	if err != nil {
 		t.Fatalf("Could not generate temp credentials")
@@ -94,7 +97,7 @@ func testWithTempCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 		res,
 		map[string]string{
 			"X-Taskcluster-Proxy-Version":     version,
-			"X-Taskcluster-Proxy-Temp-Scopes": fmt.Sprintf("%s", tempScopes),
+			"X-Taskcluster-Proxy-Temp-Scopes": tempScopesJSON,
 			// N.B. the http library does not distinguish between header entries
 			// that have an empty "" value, and non-existing entries
 			"X-Taskcluster-Proxy-Perm-ClientId": "",
@@ -375,7 +378,7 @@ func TestOversteppedScopes(t *testing.T) {
 			res,
 			map[string]string{
 				"X-Taskcluster-Endpoint":          "https://secrets.taskcluster.net/v1/secret/garbage/pmoore/foo",
-				"X-Taskcluster-Authorized-Scopes": "[secrets:get:garbage/pmoore/foo]",
+				"X-Taskcluster-Authorized-Scopes": `["secrets:get:garbage/pmoore/foo"]`,
 			},
 		)
 		return res

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -158,7 +158,7 @@ func TestBewit(t *testing.T) {
 		res := httptest.NewRecorder()
 
 		// Function to test
-		routes.ServeHTTP(res, req)
+		routes.BewitHandler(res, req)
 
 		// Validate results
 		bewitUrl := res.Header().Get("Location")
@@ -219,7 +219,7 @@ func TestAuthorizationDelegate(t *testing.T) {
 			res := httptest.NewRecorder()
 
 			// Function to test
-			routes.ServeHTTP(res, req)
+			routes.RootHandler(res, req)
 			return res
 		}
 	}
@@ -296,7 +296,7 @@ func TestAPICallWithPayload(t *testing.T) {
 		res := httptest.NewRecorder()
 
 		// Function to test
-		routes.ServeHTTP(res, req)
+		routes.RootHandler(res, req)
 
 		t.Logf("Created task https://queue.taskcluster.net/v1/task/%v", taskId)
 		return res
@@ -330,7 +330,7 @@ func TestNon200HasErrorBody(t *testing.T) {
 		res := httptest.NewRecorder()
 
 		// Function to test
-		routes.ServeHTTP(res, req)
+		routes.RootHandler(res, req)
 
 		// Validate results
 		return res
@@ -367,7 +367,7 @@ func TestOversteppedScopes(t *testing.T) {
 		res := httptest.NewRecorder()
 
 		// Function to test
-		routes.ServeHTTP(res, req)
+		routes.RootHandler(res, req)
 
 		// Validate results
 		checkHeaders(
@@ -405,7 +405,7 @@ func TestBadCredsReturns500(t *testing.T) {
 	res := httptest.NewRecorder()
 
 	// Function to test
-	routes.ServeHTTP(res, req)
+	routes.RootHandler(res, req)
 	// Validate results
 	checkStatusCode(t, res, 500)
 }

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -412,3 +412,41 @@ func TestBadCredsReturns500(t *testing.T) {
 	// Validate results
 	checkStatusCode(t, res, 500)
 }
+
+func TestInvalidEndpoint(t *testing.T) {
+	test := func(t *testing.T, creds *tcclient.Credentials) *httptest.ResponseRecorder {
+
+		// Test setup
+		routes := Routes{
+			ConnectionData: tcclient.ConnectionData{
+				Authenticate: true,
+				Credentials:  creds,
+			},
+		}
+
+		req, err := http.NewRequest(
+			"GET",
+			"http://localhost:60024/x", // invalid endpoint
+			new(bytes.Buffer),
+		)
+		if err != nil {
+			log.Fatal(err)
+		}
+		res := httptest.NewRecorder()
+
+		// Function to test
+		routes.RootHandler(res, req)
+
+		// Validate results
+		checkHeaders(
+			t,
+			res,
+			map[string]string{
+				"X-Taskcluster-Endpoint": "",
+			},
+		)
+		return res
+	}
+	testWithTempCreds(t, test, 404)
+	testWithPermCreds(t, test, 404)
+}

--- a/credentials_update_test.go
+++ b/credentials_update_test.go
@@ -20,7 +20,7 @@ func TestCredentialsUpdate(t *testing.T) {
 	newCreds := CredentialsUpdate{
 		ClientId:    "newClientId",
 		AccessToken: "newAccessToken",
-		Certificate: "newCertificate",
+		Certificate: `{"version":1,"scopes":["scope1"]}`,
 	}
 
 	body, err := json.Marshal(&newCreds)
@@ -91,7 +91,7 @@ func (self *RoutesTest) request(method string, content []byte) (res *httptest.Re
 
 	req.ContentLength = int64(len(content))
 	res = httptest.NewRecorder()
-	self.ServeHTTP(res, req)
+	self.CredentialsHandler(res, req)
 	return
 }
 
@@ -103,7 +103,7 @@ func NewRoutesTest(t *testing.T) *RoutesTest {
 				Credentials: &tcclient.Credentials{
 					ClientId:    "clientId",
 					AccessToken: "accessToken",
-					Certificate: "certificate",
+					Certificate: `{"version":1,"scopes":["scope2"]}`,
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -105,7 +105,11 @@ func main() {
 		},
 	}
 
-	startError := http.ListenAndServe(fmt.Sprintf(":%d", port), &routes)
+	http.HandleFunc("/", routes.RootHandler)
+	http.HandleFunc("/bewit", routes.BewitHandler)
+	http.HandleFunc("/credentials", routes.CredentialsHandler)
+
+	startError := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if startError != nil {
 		log.Fatal(startError)
 	}

--- a/routes.go
+++ b/routes.go
@@ -40,13 +40,19 @@ func (self *Routes) setHeaders(res http.ResponseWriter) {
 			fmt.Fprintf(res, "TaskCluster Proxy has invalid certificate: %v\n%v", self.Credentials, err)
 			return
 		} else {
-			headersToSend.Set("X-Taskcluster-Proxy-Temp-Scopes", fmt.Sprintf("%s", cert.Scopes))
+			jsonTempScopes, err := json.Marshal(cert.Scopes)
+			if err == nil {
+				headersToSend.Set("X-Taskcluster-Proxy-Temp-Scopes", string(jsonTempScopes))
+			}
 		}
 	} else {
 		headersToSend.Set("X-Taskcluster-Proxy-Perm-ClientId", fmt.Sprintf("%s", self.Credentials.ClientId))
 	}
 	if authScopes := self.Credentials.AuthorizedScopes; authScopes != nil {
-		headersToSend.Set("X-Taskcluster-Authorized-Scopes", fmt.Sprintf("%s", authScopes))
+		jsonAuthScopes, err := json.Marshal(authScopes)
+		if err == nil {
+			headersToSend.Set("X-Taskcluster-Authorized-Scopes", string(jsonAuthScopes))
+		}
 	}
 }
 


### PR DESCRIPTION
Also this adds the X-Taskcluster-Proxy http response headers to the /credentials endpoint...

This also fixes the bug where if the url path was shorter than 5 characters, there would be no response because the request would cause a panic.