### PR TITLE
Capture temp creds clientId in http response headers too

### DIFF
--- a/authorization_test.go
+++ b/authorization_test.go
@@ -63,7 +63,8 @@ func testWithPermCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 			"X-Taskcluster-Proxy-Perm-ClientId": permCredentials.ClientId,
 			// N.B. the http library does not distinguish between header entries
 			// that have an empty "" value, and non-existing entries
-			"X-Taskcluster-Proxy-Temp-Scopes": "",
+			"X-Taskcluster-Proxy-Temp-ClientId": "",
+			"X-Taskcluster-Proxy-Temp-Scopes":   "",
 		},
 	)
 }
@@ -82,7 +83,8 @@ func testWithTempCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 
 	tempScopesJSON := `["auth:azure-table-access:fakeaccount/DuMmYtAbLe","queue:define-task:win-provisioner/win2008-worker","queue:get-artifact:private/build/sources.xml","queue:route:tc-treeherder.mozilla-inbound.*","queue:route:tc-treeherder-stage.mozilla-inbound.*","queue:task-priority:high","test-worker:image:toastposter/pumpkin:0.5.6"]`
 
-	tempCredentials, err := permCredentials.CreateTemporaryCredentials(1*time.Hour, tempScopes...)
+	tempCredsClientId := slugid.Nice()
+	tempCredentials, err := permCredentials.CreateNamedTemporaryCredentials(tempCredsClientId, 1*time.Hour, tempScopes...)
 	if err != nil {
 		t.Fatalf("Could not generate temp credentials")
 	}
@@ -96,8 +98,9 @@ func testWithTempCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 		t,
 		res,
 		map[string]string{
-			"X-Taskcluster-Proxy-Version":     version,
-			"X-Taskcluster-Proxy-Temp-Scopes": tempScopesJSON,
+			"X-Taskcluster-Proxy-Version":       version,
+			"X-Taskcluster-Proxy-Temp-ClientId": tempCredsClientId,
+			"X-Taskcluster-Proxy-Temp-Scopes":   tempScopesJSON,
 			// N.B. the http library does not distinguish between header entries
 			// that have an empty "" value, and non-existing entries
 			"X-Taskcluster-Proxy-Perm-ClientId": "",

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -83,7 +83,7 @@ func testWithTempCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 
 	tempScopesJSON := `["auth:azure-table-access:fakeaccount/DuMmYtAbLe","queue:define-task:win-provisioner/win2008-worker","queue:get-artifact:private/build/sources.xml","queue:route:tc-treeherder.mozilla-inbound.*","queue:route:tc-treeherder-stage.mozilla-inbound.*","queue:task-priority:high","test-worker:image:toastposter/pumpkin:0.5.6"]`
 
-	tempCredsClientId := "dummy-test-clientId/" + slugid.Nice()
+	tempCredsClientId := "garbage/" + slugid.Nice()
 	tempCredentials, err := permCredentials.CreateNamedTemporaryCredentials(tempCredsClientId, 1*time.Hour, tempScopes...)
 	if err != nil {
 		t.Fatalf("Could not generate temp credentials")

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -83,7 +83,7 @@ func testWithTempCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 
 	tempScopesJSON := `["auth:azure-table-access:fakeaccount/DuMmYtAbLe","queue:define-task:win-provisioner/win2008-worker","queue:get-artifact:private/build/sources.xml","queue:route:tc-treeherder.mozilla-inbound.*","queue:route:tc-treeherder-stage.mozilla-inbound.*","queue:task-priority:high","test-worker:image:toastposter/pumpkin:0.5.6"]`
 
-	tempCredsClientId := slugid.Nice()
+	tempCredsClientId := "dummy-test-clientId/" + slugid.Nice()
 	tempCredentials, err := permCredentials.CreateNamedTemporaryCredentials(tempCredsClientId, 1*time.Hour, tempScopes...)
 	if err != nil {
 		t.Fatalf("Could not generate temp credentials")

--- a/routes.go
+++ b/routes.go
@@ -33,20 +33,20 @@ func (self *Routes) setHeaders(res http.ResponseWriter) {
 	headersToSend := res.Header()
 	headersToSend.Set("X-Taskcluster-Proxy-Version", version)
 	cert, err := self.Credentials.Cert()
-	if cert != nil {
-		if err != nil {
-			res.WriteHeader(500)
-			// Note, self.Credentials does not expose secrets when rendered as a string
-			fmt.Fprintf(res, "TaskCluster Proxy has invalid certificate: %v\n%v", self.Credentials, err)
-			return
-		} else {
-			jsonTempScopes, err := json.Marshal(cert.Scopes)
-			if err == nil {
-				headersToSend.Set("X-Taskcluster-Proxy-Temp-Scopes", string(jsonTempScopes))
-			}
-		}
-	} else {
+	if err != nil {
+		res.WriteHeader(500)
+		// Note, self.Credentials does not expose secrets when rendered as a string
+		fmt.Fprintf(res, "TaskCluster Proxy has invalid certificate: %v\n%v", self.Credentials, err)
+		return
+	}
+	if cert == nil {
 		headersToSend.Set("X-Taskcluster-Proxy-Perm-ClientId", fmt.Sprintf("%s", self.Credentials.ClientId))
+	} else {
+		headersToSend.Set("X-Taskcluster-Proxy-Temp-ClientId", fmt.Sprintf("%s", self.Credentials.ClientId))
+		jsonTempScopes, err := json.Marshal(cert.Scopes)
+		if err == nil {
+			headersToSend.Set("X-Taskcluster-Proxy-Temp-Scopes", string(jsonTempScopes))
+		}
 	}
 	if authScopes := self.Credentials.AuthorizedScopes; authScopes != nil {
 		jsonAuthScopes, err := json.Marshal(authScopes)


### PR DESCRIPTION
This becomes useful now that we have named temp credentials.

Originated from review comment https://github.com/taskcluster/taskcluster-proxy/pull/18#discussion_r53009944 (which I only spotted after merging the PR - d'oh).