### PR TITLE
Adapted to work with upstream changes in taskcluster-client-go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ before_install:
 # end of workaround ###
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls
-- go get golang.org/x/tools/cmd/cover
-- go get golang.org/x/tools/cmd/vet
 - go get github.com/pierrre/gotestcover
 script:
 # need to test without gotestcover since error code is not reliable for gotestcover

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 # end of workaround ###
 - go get github.com/axw/gocov/gocov
 - go get github.com/mattn/goveralls
+- go get golang.org/x/tools/cmd/cover
 - go get github.com/pierrre/gotestcover
 script:
 # need to test without gotestcover since error code is not reliable for gotestcover

--- a/authorization_test.go
+++ b/authorization_test.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	permCredentials = &tcclient.Credentials{
-		ClientId:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
+		ClientID:    os.Getenv("TASKCLUSTER_CLIENT_ID"),
 		AccessToken: os.Getenv("TASKCLUSTER_ACCESS_TOKEN"),
 	}
 )
@@ -41,7 +41,7 @@ func newTestClient() *httpbackoff.Client {
 type IntegrationTest func(t *testing.T, creds *tcclient.Credentials) *httptest.ResponseRecorder
 
 func skipIfNoPermCreds(t *testing.T) {
-	if permCredentials.ClientId == "" {
+	if permCredentials.ClientID == "" {
 		t.Skip("TASKCLUSTER_CLIENT_ID not set - skipping test")
 	}
 	if permCredentials.AccessToken == "" {
@@ -62,7 +62,7 @@ func testWithPermCreds(t *testing.T, test IntegrationTest, expectedStatusCode in
 		res,
 		map[string]string{
 			"X-Taskcluster-Proxy-Version":       version,
-			"X-Taskcluster-Proxy-Perm-ClientId": permCredentials.ClientId,
+			"X-Taskcluster-Proxy-Perm-ClientId": permCredentials.ClientID,
 			// N.B. the http library does not distinguish between header entries
 			// that have an empty "" value, and non-existing entries
 			"X-Taskcluster-Proxy-Temp-ClientId": "",
@@ -199,7 +199,7 @@ func TestAuthorizationDelegate(t *testing.T) {
 				ConnectionData: tcclient.ConnectionData{
 					Authenticate: true,
 					Credentials: &tcclient.Credentials{
-						ClientId:         creds.ClientId,
+						ClientID:         creds.ClientID,
 						AccessToken:      creds.AccessToken,
 						Certificate:      creds.Certificate,
 						AuthorizedScopes: scopes,
@@ -394,7 +394,7 @@ func TestBadCredsReturns500(t *testing.T) {
 		ConnectionData: tcclient.ConnectionData{
 			Authenticate: true,
 			Credentials: &tcclient.Credentials{
-				ClientId:    "abc",
+				ClientID:    "abc",
 				AccessToken: "def",
 				Certificate: "ghi", // baaaad certificate
 			},

--- a/credentials_update_test.go
+++ b/credentials_update_test.go
@@ -53,11 +53,11 @@ func TestCredentialsUpdate(t *testing.T) {
 		t.Fatal("Request error %d: %s", response.Code, string(content))
 	}
 
-	if routes.Credentials.ClientId != newCreds.ClientId {
+	if routes.Credentials.ClientID != newCreds.ClientId {
 		t.Errorf(
 			"ClientId should be \"%s\", but got \"%s\"",
 			newCreds.ClientId,
-			routes.Credentials.ClientId,
+			routes.Credentials.ClientID,
 		)
 	}
 
@@ -101,7 +101,7 @@ func NewRoutesTest(t *testing.T) *RoutesTest {
 			ConnectionData: tcclient.ConnectionData{
 				Authenticate: true,
 				Credentials: &tcclient.Credentials{
-					ClientId:    "clientId",
+					ClientID:    "clientId",
 					AccessToken: "accessToken",
 					Certificate: `{"version":1,"scopes":["scope2"]}`,
 				},

--- a/main.go
+++ b/main.go
@@ -81,7 +81,7 @@ func main() {
 	}
 
 	creds := &tcclient.Credentials{
-		ClientId:    clientId.(string),
+		ClientID:    clientId.(string),
 		AccessToken: accessToken.(string),
 		Certificate: certificate.(string),
 	}
@@ -89,7 +89,7 @@ func main() {
 	myQueue := queue.New(creds)
 
 	// Fetch the task to get the scopes we should be using...
-	task, _, err := myQueue.Task(taskId)
+	task, err := myQueue.Task(taskId)
 	if err != nil {
 		log.Fatalf("Could not fetch taskcluster task '%s' : %s", taskId, err)
 	}

--- a/routes.go
+++ b/routes.go
@@ -40,9 +40,9 @@ func (self *Routes) setHeaders(res http.ResponseWriter) {
 		return
 	}
 	if cert == nil {
-		headersToSend.Set("X-Taskcluster-Proxy-Perm-ClientId", fmt.Sprintf("%s", self.Credentials.ClientId))
+		headersToSend.Set("X-Taskcluster-Proxy-Perm-ClientId", fmt.Sprintf("%s", self.Credentials.ClientID))
 	} else {
-		headersToSend.Set("X-Taskcluster-Proxy-Temp-ClientId", fmt.Sprintf("%s", self.Credentials.ClientId))
+		headersToSend.Set("X-Taskcluster-Proxy-Temp-ClientId", fmt.Sprintf("%s", self.Credentials.ClientID))
 		jsonTempScopes, err := json.Marshal(cert.Scopes)
 		if err == nil {
 			headersToSend.Set("X-Taskcluster-Proxy-Temp-Scopes", string(jsonTempScopes))
@@ -108,7 +108,7 @@ func (self *Routes) CredentialsHandler(res http.ResponseWriter, req *http.Reques
 
 	self.lock.Lock()
 	defer self.lock.Unlock()
-	self.Credentials.ClientId = credentials.ClientId
+	self.Credentials.ClientID = credentials.ClientId
 	self.Credentials.AccessToken = credentials.AccessToken
 	self.Credentials.Certificate = credentials.Certificate
 
@@ -172,13 +172,13 @@ func (self *Routes) RootHandler(res http.ResponseWriter, req *http.Request) {
 	}
 
 	// Map the headers from the proxy back into our proxyResponse
-	for key, _ := range cs.HttpResponse.Header {
-		res.Header().Set(key, cs.HttpResponse.Header.Get(key))
+	for key, _ := range cs.HTTPResponse.Header {
+		res.Header().Set(key, cs.HTTPResponse.Header.Get(key))
 	}
 
 	// Write the proxyResponse headers and status.
-	res.WriteHeader(cs.HttpResponse.StatusCode)
+	res.WriteHeader(cs.HTTPResponse.StatusCode)
 
 	// Proxy the proxyResponse body from the endpoint to our response.
-	res.Write([]byte(cs.HttpResponseBody))
+	res.Write([]byte(cs.HTTPResponseBody))
 }


### PR DESCRIPTION
Upstream removed `CallSummary` and made some lint fixes.