### PR TITLE
Bug 1285197 - fix go get warning for taskcluster-client-go

### DIFF
--- a/authorization_test.go
+++ b/authorization_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/taskcluster/httpbackoff"
 	"github.com/taskcluster/slugid-go/slugid"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
 var (

--- a/credentials_update_test.go
+++ b/credentials_update_test.go
@@ -8,7 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 )
 
 type RoutesTest struct {

--- a/main.go
+++ b/main.go
@@ -8,8 +8,8 @@ import (
 	"strconv"
 
 	docopt "github.com/docopt/docopt-go"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	"github.com/taskcluster/taskcluster-client-go/queue"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
 )
 
 var version = "Taskcluster proxy 3.0.8"

--- a/routes.go
+++ b/routes.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/taskcluster/httpbackoff"
-	"github.com/taskcluster/taskcluster-client-go/tcclient"
+	tcclient "github.com/taskcluster/taskcluster-client-go"
 	tc "github.com/taskcluster/taskcluster-proxy/taskcluster"
 )
 


### PR DESCRIPTION
This depends on taskcluster/taskcluster-client-go#15 so I would expect travis to fail for this PR until that has landed. When the other PR lands, you should be able to rerun the travis jobs on this PR.