### PR TITLE
Bug 1318411 - Proxy should not strip querystring, also avoid hardcodi…

### DIFF
--- a/authorization_test.go
+++ b/authorization_test.go
@@ -429,7 +429,7 @@ func TestInvalidEndpoint(t *testing.T) {
 
 		req, err := http.NewRequest(
 			"GET",
-			"http://localhost:60024/x", // invalid endpoint
+			"http://localhost:60024/x@/", // invalid endpoint
 			new(bytes.Buffer),
 		)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -105,9 +105,9 @@ func main() {
 		},
 	}
 
-	http.HandleFunc("/", routes.RootHandler)
 	http.HandleFunc("/bewit", routes.BewitHandler)
 	http.HandleFunc("/credentials", routes.CredentialsHandler)
+	http.HandleFunc("/", routes.RootHandler)
 
 	startError := http.ListenAndServe(fmt.Sprintf(":%d", port), nil)
 	if startError != nil {

--- a/taskcluster/services.go
+++ b/taskcluster/services.go
@@ -3,54 +3,75 @@ package taskcluster
 import (
 	"fmt"
 	url "net/url"
-	s "strings"
+	"regexp"
+	"strings"
 )
 
+// Services can convert urls to proxied urls
 type Services struct {
-	Endpoints map[string]string
+	Domain string
 }
 
+// NewServices create a Service with default domain
 func NewServices() Services {
-	// Hardcoded list of services provided by taskcluster.
-	endpoints := map[string]string{
-		// Each service endpoint must end in a '/'.
-		"auth":            "https://auth.taskcluster.net/",
-		"aws-provisioner": "https://aws-provisioner.taskcluster.net/",
-		"github":          "https://github.taskcluster.net/",
-		"hooks":           "https://hooks.taskcluster.net/",
-		"index":           "https://index.taskcluster.net/",
-		"purge-cache":     "https://purge-cache.taskcluster.net/",
-		"queue":           "https://queue.taskcluster.net/",
-		"scheduler":       "https://scheduler.taskcluster.net/",
-		"secrets":         "https://secrets.taskcluster.net/",
-	}
-
-	return Services{Endpoints: endpoints}
+	return Services{Domain: "taskcluster.net"}
 }
 
-// Convert a url for the proxy server into a url for the proper taskcluster
+var hostnamePattern = regexp.MustCompile(`^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$`)
+
+// ConvertPath converts a url for the proxy server into a url for the proper taskcluster
 // service.
 //
 // Examples:
 //
 // "/queue/v1/stuff" -> "http://queue.taskcluster.net/v1/stuff"
 //
-func (self *Services) ConvertPath(url *url.URL) (*url.URL, error) {
-	// First part of the path is the service name.
-	pathParts := s.Split(url.Path[1:], "/")
-	service := pathParts[0]
-	serviceEndpoint, endpointExists := self.Endpoints[service]
+func (s *Services) ConvertPath(u *url.URL) (*url.URL, error) {
+	// Find raw path, removing the initial slash if present
+	// afaik initial slash should always be there.
+	rawPath := u.EscapedPath()
+	if len(rawPath) > 0 && rawPath[0] == '/' {
+		rawPath = rawPath[1:]
+	}
 
-	// If an invalid endpoint was passed return an error.
-	if !endpointExists {
-		return url, fmt.Errorf("%s is not a valid taskcluster service", service)
+	// First part of the path is the service name.
+	i := strings.IndexByte(rawPath, '/')
+	if i == -1 {
+		i = len(rawPath)
+	}
+	service := rawPath[:i]
+	path := rawPath[i:]
+
+	// Remove slash from start of path
+	if len(path) > 0 && path[0] == '/' {
+		path = path[1:]
+	}
+
+	// If service not a valid hostname return error
+	if !hostnamePattern.MatchString(service) {
+		return u, fmt.Errorf("%s is not a valid taskcluster service", service)
+	}
+
+	var serviceEndpoint string
+	// If service name doesn't contain a dot, we assume it's a shortcut
+	// like: auth, queue, ... and suffix with self.Domain
+	if !strings.Contains(service, ".") {
+		// This is pretty much legacy
+		serviceEndpoint = "https://" + service + "." + s.Domain
+	} else {
+		// Otherwise we assume service is the hostname
+		serviceEndpoint = "https://" + service
 	}
 
 	// Attempt to construct a new endpoint
-	realEndpoint, err := url.Parse(serviceEndpoint + s.Join(pathParts[1:], "/"))
+	query := u.RawQuery
+	if query != "" {
+		query = "?" + query
+	}
+	realEndpoint, err := url.Parse(serviceEndpoint + "/" + path + query)
 
 	if err != nil {
-		return url, err
+		return u, err
 	}
 
 	return realEndpoint, nil

--- a/taskcluster/services_test.go
+++ b/taskcluster/services_test.go
@@ -40,6 +40,10 @@ var urlConversions = []struct {
 		"https://queue.taskcluster.net/x/y/z?key=value",
 	},
 	{
+		"https://xfoo.com/queue/x/y%20/z?key=value&key2=value2",
+		"https://queue.taskcluster.net/x/y%20/z?key=value&key2=value2",
+	},
+	{
 		"https://xfoo.com/myqueue.somewhere.com/v1/task/tsdtwe34tgs%2ff5yh?k=v%20m",
 		"https://myqueue.somewhere.com/v1/task/tsdtwe34tgs%2ff5yh?k=v%20m",
 	},

--- a/taskcluster/services_test.go
+++ b/taskcluster/services_test.go
@@ -27,6 +27,22 @@ var urlConversions = []struct {
 		"https://xfoo.com/aws-provisioner/x/y/z",
 		"https://aws-provisioner.taskcluster.net/x/y/z",
 	},
+	{
+		"https://xfoo.com/queue/x/y%2fz",
+		"https://queue.taskcluster.net/x/y%2fz",
+	},
+	{
+		"https://xfoo.com/queue/x/y%2fz/a",
+		"https://queue.taskcluster.net/x/y%2fz/a",
+	},
+	{
+		"https://xfoo.com/queue/x/y/z?key=value",
+		"https://queue.taskcluster.net/x/y/z?key=value",
+	},
+	{
+		"https://xfoo.com/myqueue.somewhere.com/v1/task/tsdtwe34tgs%2ff5yh?k=v%20m",
+		"https://myqueue.somewhere.com/v1/task/tsdtwe34tgs%2ff5yh?k=v%20m",
+	},
 }
 
 func TestConvertPathForQueue(t *testing.T) {


### PR DESCRIPTION
…ng hostnames

This makes it so that:
```
http://taskcluster/auth/...    -> https://auth.taskcluster.net/...
http://taskcluster/myhost.example.com/... -> https://myhost.example.com/...
```

Generically:
```
http://taskcluster/<host>/<path>[?<query>]

if <host> contains a dot '.':
  https://<host>/<path>[?<query>]

if <host> doesn't contain a dot '.':
  https://<host>.taskcluster.net/<path>[?<query>]
```

The hawk HMAC signature contains the hostname, so a signed request to `myevil-service.ngrok.io` can't be used to obtain a request signature that can be exploited to create a task on the queue...
It does reveal the certificate from the temporary credentials, but those are useless with the accessToken, and technically not secret. 