### PR TITLE
Bug 1394894 - support taskIds starting with a '-'

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ TODO:
 7. Start docker daemon, if not already running (e.g. `boot2docker start`)
 8. Refresh your environment in case you have cached dependencies with `go get -u ./...`
 9. `./build.sh taskcluster/taskcluster-proxy:X.Y.Z` (no `v` prefix)
-10. `./build.sh taskcluster/taskcluster-proxy:latest`
+10. `docker tag -f taskcluster/taskcluster-proxy:X.Y.Z taskcluster/taskcluster-proxy:latest` (no `v` prefix in version)
 11. `docker push taskcluster/taskcluster-proxy:X.Y.Z` (no `v` prefix in version)
 12. `docker push taskcluster/taskcluster-proxy:latest`
-13. Confirm releases appear [here](https://hub.docker.com/r/taskcluster/taskcluster-proxy/tags/)
+13. Confirm releases `X.Y.Z` and `latest` appear [here](https://hub.docker.com/r/taskcluster/taskcluster-proxy/tags/)

--- a/README.md
+++ b/README.md
@@ -43,13 +43,15 @@ particular task but additional scopes may be added by specifying them after the
 task id.
 
   Usage:
-    taskcluster-proxy [options] <taskId> [<scope>...]
-    taskcluster-proxy --help
+    taskcluster-proxy [options] [<scope>...]
+    taskcluster-proxy -h|--help
+    taskcluster-proxy --version
 
   Options:
     -h --help                       Show this help screen.
     --version                       Show the taskcluster-proxy version number.
     -p --port <port>                Port to bind the proxy server to [default: 8080].
+    -t --task-id <taskId>           Restrict given scopes to those defined in taskId.
     --client-id <clientId>          Use a specific auth.taskcluster hawk client id [default: ].
     --access-token <accessToken>    Use a specific auth.taskcluster hawk access token [default: ].
     --certificate <certificate>     Use a specific auth.taskcluster hawk certificate [default: ].
@@ -75,7 +77,7 @@ connection (typically https://localhost:60024/).
 
 ```sh
 # Start the proxy server; note that 2sz... is the taskId
-taskcluster-proxy 2szAy1JzSr6pyjVCdiTcoQ -p 60024
+taskcluster-proxy -t 2szAy1JzSr6pyjVCdiTcoQ -p 60024
 ```
 
 #### Fetch a task
@@ -98,7 +100,7 @@ curl localhost:60024/bewit --data 'https://queue.taskcluster.net/v1/task/2szAy1J
 The proxy runs fine natively, but if you wish, you can also create a docker image to run it in.
 
 ```sh
-./build.sh user/taskcluster-proxy
+./build.sh 'user/taskcluster-proxy:latest'
 ```
 
 ## Endpoints

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+set -e
+
 help() {
   echo ""
   echo "Builds proxy server (For linux) and places into a docker container."

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/taskcluster/taskcluster-client-go/queue"
 )
 
-var version = "Taskcluster proxy 3.1.1"
+var version = "Taskcluster proxy 4.0.0"
 var usage = `
 Taskcluster authentication proxy. By default this pulls all scopes from a
 particular task but additional scopes may be added by specifying them after the

--- a/main.go
+++ b/main.go
@@ -12,20 +12,22 @@ import (
 	"github.com/taskcluster/taskcluster-client-go/queue"
 )
 
-var version = "Taskcluster proxy 3.1.0"
+var version = "Taskcluster proxy 3.1.1"
 var usage = `
 Taskcluster authentication proxy. By default this pulls all scopes from a
 particular task but additional scopes may be added by specifying them after the
 task id.
 
   Usage:
-    taskcluster-proxy [options] <taskId> [<scope>...]
-    taskcluster-proxy --help
+    taskcluster-proxy [options] [<scope>...]
+    taskcluster-proxy -h|--help
+    taskcluster-proxy --version
 
   Options:
     -h --help                       Show this help screen.
     --version                       Show the taskcluster-proxy version number.
     -p --port <port>                Port to bind the proxy server to [default: 8080].
+    -t --task-id <taskId>           Restrict given scopes to those defined in taskId.
     --client-id <clientId>          Use a specific auth.taskcluster hawk client id [default: ].
     --access-token <accessToken>    Use a specific auth.taskcluster hawk access token [default: ].
     --certificate <certificate>     Use a specific auth.taskcluster hawk certificate [default: ].
@@ -35,7 +37,6 @@ func main() {
 	// Parse the docopt string and exit on any error or help message.
 	arguments, err := docopt.Parse(usage, nil, true, version, false, true)
 
-	taskId := arguments["<taskId>"].(string)
 	port, err := strconv.Atoi(arguments["--port"].(string))
 	if err != nil {
 		log.Fatalf("Failed to convert port to integer")
@@ -66,7 +67,8 @@ func main() {
 		certificate = os.Getenv("TASKCLUSTER_CERTIFICATE")
 	}
 
-	log.Printf("clientId: '%v'\naccessToken: '%v'\ncertificate: '%v'\n", clientId, accessToken, certificate)
+	log.Printf("clientId: '%v'", clientId)
+	log.Printf("accessToken: '%v'", accessToken)
 
 	// Ensure we have credentials our auth proxy is pretty much useless without
 	// it.
@@ -78,6 +80,8 @@ func main() {
 
 	if certificate == "" {
 		log.Println("Warning - no taskcluster certificate set - assuming permanent credentials are being used")
+	} else {
+		log.Printf("certificate: '%v'", certificate)
 	}
 
 	creds := &tcclient.Credentials{
@@ -86,17 +90,26 @@ func main() {
 		Certificate: certificate.(string),
 	}
 
-	myQueue := queue.New(creds)
+	if arguments["--task-id"] != nil {
+		taskId := arguments["--task-id"].(string)
+		log.Printf("taskId: '%v'", taskId)
+		myQueue := queue.New(new(tcclient.Credentials))
 
-	// Fetch the task to get the scopes we should be using...
-	task, err := myQueue.Task(taskId)
-	if err != nil {
-		log.Fatalf("Could not fetch taskcluster task '%s' : %s", taskId, err)
+		// Fetch the task to get the scopes we should be using...
+		task, err := myQueue.Task(taskId)
+		if err != nil {
+			log.Fatalf("Could not fetch taskcluster task '%s' : %s", taskId, err)
+		}
+
+		creds.AuthorizedScopes = append(additionalScopes, task.Scopes...)
 	}
 
-	creds.AuthorizedScopes = append(additionalScopes, task.Scopes...)
-
-	log.Println("Proxy with scopes: ", creds.AuthorizedScopes)
+	if len(creds.AuthorizedScopes) == 0 {
+		creds.AuthorizedScopes = nil
+		log.Print("Proxy has full scopes of provided credentials - no scope reduction being applied")
+	} else {
+		log.Println("Proxy with scopes: ", creds.AuthorizedScopes)
+	}
 
 	routes := Routes{
 		Client: tcclient.Client{

--- a/main.go
+++ b/main.go
@@ -50,32 +50,27 @@ func main() {
 		additionalScopes = make([]string, 0)
 	}
 
-	// Client is is required but has a default.
 	clientId := arguments["--client-id"]
 	if clientId == nil || clientId == "" {
 		clientId = os.Getenv("TASKCLUSTER_CLIENT_ID")
 	}
+	if clientId == "" {
+		log.Fatal("Client ID must be passed via environment variable TASKCLUSTER_CLIENT_ID or command line option --client-id")
+	}
+	log.Printf("clientId: '%v'", clientId)
 
-	// Access token is also required but has a default.
 	accessToken := arguments["--access-token"]
 	if accessToken == nil || accessToken == "" {
 		accessToken = os.Getenv("TASKCLUSTER_ACCESS_TOKEN")
 	}
+	if accessToken == "" {
+		log.Fatal("Access token must be passed via environment variable TASKCLUSTER_ACCESS_TOKEN or command line option --access-token")
+	}
+	log.Print("accessToken: <not shown>")
 
 	certificate := arguments["--certificate"]
 	if certificate == nil || certificate == "" {
 		certificate = os.Getenv("TASKCLUSTER_CERTIFICATE")
-	}
-
-	log.Printf("clientId: '%v'", clientId)
-	log.Printf("accessToken: '%v'", accessToken)
-
-	// Ensure we have credentials our auth proxy is pretty much useless without
-	// it.
-	if accessToken == "" || clientId == "" {
-		log.Fatalf(
-			"Credentials must be passed via environment variables or flags...",
-		)
 	}
 
 	if certificate == "" {


### PR DESCRIPTION
```
pmoore@Petes-iMac:~/go/src/github.com/taskcluster/taskcluster-proxy bug1394894 $ taskcluster-proxy --task-id -XxUtCX2SR2DA9Y7sOQ49g
2017/08/30 12:06:06 clientId: 'mozilla-ldap/pmoore@mozilla.com/dev'
2017/08/30 12:06:06 accessToken: '***************'
2017/08/30 12:06:06 Warning - no taskcluster certificate set - assuming permanent credentials are being used
2017/08/30 12:06:06 taskId: '-XxUtCX2SR2DA9Y7sOQ49g'
2017/08/30 12:06:08 Proxy with scopes:  [queue:define-task:aws-provisioner-v1/gecko-3-b-linux queue:create-task:aws-provisioner-v1/gecko-3-b-linux queue:define-task:aws-provisioner-v1/build-c4-2xlarge queue:create-task:aws-provisioner-v1/build-c4-2xlarge secrets:get:project/releng/snapcraft/firefox/edge]
...
...
```

Note, I _intentionally_ made supplying of a `taskId` optional, as this is something I've been missing for a while (e.g. for running a taskcluster-proxy locally, to make it easy to curl endpoints via command-line rather than needing to write python/node/go code). Admittedly it isn't required for this bug, but it was a useful time to slip it in. :wink:

__IMPORTANT__: I've bumped the version number to 4.0.0 as the command line syntax changed, and is __not__ backwardly-compatible (you now specify taskId using `-t` or `--task-id`). Therefore, when we upgrade docker worker to use new taskcluster-proxy, we'll also need to make it use the new syntax.