### PR TITLE
Read lock credentials and use go 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,32 +1,27 @@
 language: go
-sudo: false
 go:
-  - 1.8
+  - 1.9
+
 env:
-  - "MY_GOOS=linux MY_GOARCH=amd64"
-  - "MY_GOOS=darwin MY_GOARCH=amd64"
-  - "MY_GOOS=windows MY_GOARCH=amd64"
-  - "MY_GOOS=windows MY_GOARCH=386"
+  - "GIMME_OS=linux GIMME_ARCH=amd64"
+  - "GIMME_OS=darwin GIMME_ARCH=amd64"
+  - "GIMME_OS=windows GIMME_ARCH=amd64"
+  - "GIMME_OS=windows GIMME_ARCH=386"
+
 before_install:
-# workaround for travis-ci/gimme#42
-  - curl -o go.tar.gz -sL https://storage.googleapis.com/golang/go1.7.4.linux-amd64.tar.gz
-  - tar -C $HOME -xf go.tar.gz
-  - rm go.tar.gz
-  - export GOROOT="${HOME}/go"
-  - export PATH="${GOROOT}/bin:${PATH}"
-  - export GOOS="${MY_GOOS}"
-  - export GOARCH="${MY_GOARCH}"
-# end of workaround ###
   - go get github.com/axw/gocov/gocov
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/pierrre/gotestcover
+
 script:
 # need to test without gotestcover since error code is not reliable for gotestcover
-  - "test $GOOS.$GOARCH != linux.amd64 || go test -v ./..."
+  - "test $GIMME_OS.$GIMME_ARCH != linux.amd64 || go test -v ./..."
+
 after_script:
 # using gotestcover means tests get run again, but need to do this since exit code of gotestcover is unreliable
-  - "if test $GOOS.$GOARCH = linux.amd64; ${GOPATH}/bin/gotestcover -v -coverprofile=coverage.report ./...; go tool cover -func=coverage.report; ${HOME}/gopath/bin/goveralls -coverprofile=coverage.report -service=travis-ci; fi"
+  - "if test $GIMME_OS.$GIMME_ARCH = linux.amd64; ${GOPATH}/bin/gotestcover -v -coverprofile=coverage.report ./...; go tool cover -func=coverage.report; ${HOME}/gopath/bin/goveralls -coverprofile=coverage.report -service=travis-ci; fi"
+
 notifications:
   irc:
     channels:
@@ -38,8 +33,10 @@ notifications:
     - 'Change view : %{compare_url}'
     - 'Build details : %{build_url}'
     - 'Commit message : %{commit_message}'
+
 before_deploy:
 - source .travis_rename_releases.sh
+
 deploy:
   provider: releases
   api_key:

--- a/routes.go
+++ b/routes.go
@@ -32,6 +32,8 @@ var httpClient = &http.Client{}
 func (self *Routes) setHeaders(res http.ResponseWriter) {
 	headersToSend := res.Header()
 	headersToSend.Set("X-Taskcluster-Proxy-Version", version)
+	self.lock.RLock()
+	defer self.lock.RUnlock()
 	cert, err := self.Credentials.Cert()
 	if err != nil {
 		res.WriteHeader(500)


### PR DESCRIPTION
Two changes here:

1) Use go 1.9 in travis (and travis config cleanup)
2) Use read lock when reading credentials (see #26)