### PR TITLE
Ensure AuthorizedScopes is non-nil if --task-id is specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ TODO:
 7. Start docker daemon, if not already running (e.g. `boot2docker start`)
 8. Refresh your environment in case you have cached dependencies with `go get -u ./...`
 9. `./build.sh taskcluster/taskcluster-proxy:X.Y.Z` (no `v` prefix)
-10. `docker tag -f taskcluster/taskcluster-proxy:X.Y.Z taskcluster/taskcluster-proxy:latest` (no `v` prefix in version)
+10. `docker tag taskcluster/taskcluster-proxy:X.Y.Z taskcluster/taskcluster-proxy:latest` (no `v` prefix in version)
 11. `docker push taskcluster/taskcluster-proxy:X.Y.Z` (no `v` prefix in version)
 12. `docker push taskcluster/taskcluster-proxy:latest`
 13. Confirm releases `X.Y.Z` and `latest` appear [here](https://hub.docker.com/r/taskcluster/taskcluster-proxy/tags/)

--- a/credentials_update_test.go
+++ b/credentials_update_test.go
@@ -44,13 +44,13 @@ func TestCredentialsUpdate(t *testing.T) {
 	response = routes.request("PUT", []byte("{\"badJS0n!"))
 	if response.Code != 400 {
 		content, _ := ioutil.ReadAll(response.Body)
-		t.Fatal("Request error %d: %s", response.Code, string(content))
+		t.Fatalf("Request error %d: %s", response.Code, string(content))
 	}
 
 	response = routes.request("PUT", body)
 	if response.Code != 200 {
 		content, _ := ioutil.ReadAll(response.Body)
-		t.Fatal("Request error %d: %s", response.Code, string(content))
+		t.Fatalf("Request error %d: %s", response.Code, string(content))
 	}
 
 	if routes.Credentials.ClientID != newCreds.ClientId {

--- a/parse_test.go
+++ b/parse_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+func TestNoTaskNoScopes(t *testing.T) {
+	routes, port := ParseCommandArgs([]string{})
+	if routes.Credentials.AuthorizedScopes != nil {
+		t.Fatalf("Was expecting no AuthorizedScopes restriction, but got: %v", routes.Credentials.AuthorizedScopes)
+	}
+	if port != 8080 {
+		t.Fatalf("Was expecting port 80, but got port %v.", port)
+	}
+}
+
+func TestNondefaultPort(t *testing.T) {
+	_, port := ParseCommandArgs([]string{
+		"--port",
+		"12345",
+	})
+	if port != 12345 {
+		t.Fatalf("Was expecting port 12345, but got port %v.", port)
+	}
+}
+
+func TestWithTwoScopes(t *testing.T) {
+	routes, port := ParseCommandArgs([]string{
+		"--client-id", "abc",
+		"--certificate", "def",
+		"--access-token", "ghi",
+		"--port", "12345",
+		// scopes
+		"a:b:c",
+		"d:e:f",
+	})
+	if port != 12345 {
+		t.Fatalf("Was expecting port 12345, but got port %v.", port)
+	}
+	if clientID := routes.Credentials.ClientID; clientID != "abc" {
+		t.Fatalf("Was expecting client id 'abc', but got client id %v.", clientID)
+	}
+	if cert := routes.Credentials.Certificate; cert != "def" {
+		t.Fatalf("Was expecting certificate 'def', but got certificate %v.", cert)
+	}
+	if accessToken := routes.Credentials.AccessToken; accessToken != "ghi" {
+		t.Fatalf("Was expecting access token 'ghi', but got access token %v.", accessToken)
+	}
+	if scopes := routes.Credentials.AuthorizedScopes; len(scopes) != 2 || (scopes[0]+" "+scopes[1] != "a:b:c d:e:f" && scopes[1]+" "+scopes[0] != "a:b:c d:e:f") {
+		t.Fatalf("Was expecting authorized scopes to contain 'a:b:c' and 'd:e:f', but instead got: %v", scopes)
+	}
+}
+
+func TestWithTaskWithNoScopes(t *testing.T) {
+	routes, _ := ParseCommandArgs([]string{
+		"--task-id", "KTBKfEgxR5GdfIIREQIvFQ",
+	})
+	if scopes := routes.Credentials.AuthorizedScopes; scopes == nil || len(scopes) > 0 {
+		t.Fatalf("Was expecting authorized scopes to be an empty non-nil array, but instead got: %v", scopes)
+	}
+}
+
+func TestWithTaskWithScopes(t *testing.T) {
+	routes, _ := ParseCommandArgs([]string{
+		"--task-id", "eQgo-rE5RHWgHeYRKGrHKA",
+	})
+	if scopes := routes.Credentials.AuthorizedScopes; len(scopes) != 1 || scopes[0] != "queue:get-artifact:SampleArtifacts/_/X.txt" {
+		t.Fatalf("Was expecting authorized scopes to be the single scope queue:get-artifact:SampleArtifacts/_/X.txt, but instead got: %v", scopes)
+	}
+}

--- a/testdata/tasks/KTBKfEgxR5GdfIIREQIvFQ.json
+++ b/testdata/tasks/KTBKfEgxR5GdfIIREQIvFQ.json
@@ -1,0 +1,48 @@
+{
+  "provisionerId": "test-provisioner",
+  "workerType": "Ga6sJQoGRz225-RGnvbpgQ",
+  "schedulerId": "test-scheduler",
+  "taskGroupId": "OY0sHU3VTrykGZLTGZ_goQ",
+  "dependencies": [],
+  "requires": "all-completed",
+  "routes": [],
+  "priority": "lowest",
+  "retries": 1,
+  "created": "2016-09-19T12:09:54.000Z",
+  "deadline": "2016-09-20T12:09:54.000Z",
+  "expires": "2021-09-19T12:09:54.000Z",
+  "scopes": [],
+  "payload": {
+    "command": [
+      [
+        "echo",
+        "hello world!"
+      ],
+      [
+        "echo",
+        "goodbye world!"
+      ]
+    ],
+    "maxRunTime": 7200,
+    "artifacts": [
+      {
+        "path": "SampleArtifacts/_/X.txt",
+        "expires": "2021-09-19T12:09:54.000Z",
+        "type": "file"
+      }
+    ],
+    "features": {
+      "chainOfTrust": true
+    }
+  },
+  "metadata": {
+    "description": "Test task",
+    "name": "[TC] TestUpload",
+    "owner": "pmoore@mozilla.com",
+    "source": "https://github.com/taskcluster/generic-worker/blob/master/artifacts_test.go"
+  },
+  "tags": {
+    "createdForUser": "pmoore@mozilla.com"
+  },
+  "extra": {}
+}

--- a/testdata/tasks/README.md
+++ b/testdata/tasks/README.md
@@ -1,0 +1,1 @@
+This directory contains the task definitions of tasks that are used in go tests.

--- a/testdata/tasks/eQgo-rE5RHWgHeYRKGrHKA.json
+++ b/testdata/tasks/eQgo-rE5RHWgHeYRKGrHKA.json
@@ -1,0 +1,33 @@
+{
+  "provisionerId": "win2012r2",
+  "workerType": "aws-provisioner-v1",
+  "schedulerId": "-",
+  "taskGroupId": "eQgo-rE5RHWgHeYRKGrHKA",
+  "dependencies": [],
+  "requires": "all-completed",
+  "routes": [],
+  "priority": "lowest",
+  "retries": 1,
+  "created": "2018-03-02T11:07:02.080Z",
+  "deadline": "2018-03-03T11:07:02.080Z",
+  "expires": "2023-03-02T11:07:02.080Z",
+  "scopes": [
+    "queue:get-artifact:SampleArtifacts/_/X.txt"
+  ],
+  "payload": {
+    "command": [
+      "echo hello world!"
+    ],
+    "maxRunTime": 7200
+  },
+  "metadata": {
+    "description": "Test task for taskcluster-proxy unit tests",
+    "name": "TestWithTaskWithScopes",
+    "owner": "pmoore@mozilla.com",
+    "source": "https://github.com/taskcluster/taskcluster-proxy/blob/master/parse_test.go"
+  },
+  "tags": {
+    "createdForUser": "pmoore@mozilla.com"
+  },
+  "extra": {}
+}


### PR DESCRIPTION
There was a bug in the command line parsing of `taskcluster-proxy`. You can specify a command line option for a task ID, which should cause taskcluster-proxy to restrict the scopes of outbound requests to those of the supplied task ID. However, if a task ID was specified that happened to have no scopes itself, the full scopes of the taskcluster-proxy client ID would be attached to outbound requests.

The correct behaviour should be, if the task has no scopes, `AuthorizedScopes` should be set to an empty string array (rather than a nil string array). The subtle difference is that a nil `AuthorizedScopes` means, "don't restrict this client to a set of authorized scopes", whereas an empty string array for `AuthorizedScopes` means "restrict this client to have precisely no scopes".

I've pulled out command line parsing into its own function, and added some tests against it. Note, the test `TestWithTaskWithNoScopes` tests the specific bug I've fixed.

Note in production this isn't a security concern, since the proxy is started with credentials from the task claim, provided by the queue, which only have the scopes of the task. So granting the full scopes of the proxy is not a problem. This is more useful if the proxy is being used outside the scope of a running task (e.g. when used locally for testing a decision task for example).

Note, I first looked at making the command line options a bit stricter (so you explicitly have to opt-in to inherit all client scopes) - but I hit https://github.com/docopt/docopt.go/issues/54 so I've parked that idea.

Also we probably don't want to invest too much into this current taskcluster-proxy implementation, as it caches http responses in memory, and other such things, so perhaps at some point a rewrite is warranted.