### PR TITLE
Fix CI bustage and release script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,19 @@
 language: go
 go:
-  - 1.10.2
+  - 1.10.4
 
 env:
   - "GIMME_OS=linux GIMME_ARCH=amd64"
   - "GIMME_OS=linux GIMME_ARCH=arm"
-  - "GIMME_OS=linux GIMME_ARCH=arm64"
+
+  # Disabling arm64/linux while https://github.com/travis-ci/gimme/issues/154
+  # is open
+  #
+  # Note, we could fix this by installing go binary directly and setting
+  # GOOS/GOARCH; gimme isn't needed these days for cross compilation...
+  #
+  # - "GIMME_OS=linux GIMME_ARCH=arm64"
+
   - "GIMME_OS=darwin GIMME_ARCH=amd64"
   - "GIMME_OS=windows GIMME_ARCH=amd64"
   - "GIMME_OS=windows GIMME_ARCH=386"

--- a/release.sh
+++ b/release.sh
@@ -123,10 +123,10 @@ while ! curl -s -I "https://github.com/taskcluster/taskcluster-proxy/releases/do
   echo -n '.'
 done
 echo
-echo "======================================================================================================
+echo "======================================================================================================"
 echo "The github release of taskcluster-proxy ${NEW_VERSION} has been published to:"
 echo "  * https://github.com/taskcluster/taskcluster-proxy/releases"
-echo "======================================================================================================
+echo "======================================================================================================"
 echo
 
 uid="$(date +%s)"
@@ -151,10 +151,10 @@ docker push "taskcluster/taskcluster-proxy:${NEW_VERSION}"
 docker push "taskcluster/taskcluster-proxy:latest"
 echo
 echo
-echo "======================================================================================================
+echo "======================================================================================================"
 echo "The docker image for taskcluster-proxy ${NEW_VERSION} has been published to:"
 echo "  * https://hub.docker.com/r/taskcluster/taskcluster-proxy/tags/"
-echo "======================================================================================================
+echo "======================================================================================================"
 echo
 echo "It is HIGHLY RECOMMENDED to test the new docker-worker release before using it:"
 echo "  * https://github.com/taskcluster/taskcluster-proxy/tree/v${NEW_VERSION}#testing-your-locally-built-docker-container"


### PR DESCRIPTION
I spotted that the CI broke due to upstream issue travis-ci/gimme#154 so disabling arm64 builds until this is resolved, or we may choose not to use gimme in favour of a native go binary installation (since go natively supports cross compilation, so gimme isn't really needed).