### PR TITLE
Bug 1518759 - registrater APIHandler against /api/ rather than /api

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 
 	http.HandleFunc("/bewit", routes.BewitHandler)
 	http.HandleFunc("/credentials", routes.CredentialsHandler)
-	http.HandleFunc("/api", routes.APIHandler)
+	http.HandleFunc("/api/", routes.APIHandler)
 	http.HandleFunc("/", routes.RootHandler)
 
 	// Only listen on loopback interface to reduce attack surface. If we later


### PR DESCRIPTION
See [bug 1518759](https://bugzil.la/1518759) for details.

Fallout from #38.